### PR TITLE
Limit region type

### DIFF
--- a/element_facemap/facial_behavior_estimation.py
+++ b/element_facemap/facial_behavior_estimation.py
@@ -322,6 +322,8 @@ class FacialSignal(dj.Imported):
 
     def make(self, key):
         dataset, _ = get_loader_result(key, FacemapTask)
+        # Only motion SVD region type is supported.
+        dataset["rois"] = [x for x in dataset["rois"] if x["rtype"] == "motion SVD"]
 
         self.insert1(key)
 


### PR DESCRIPTION
Region types other than `motion SVD` cause bug. Limiting the region type fixes the bug when other rtypes are available. Allowing other region types will be available as an enhancement later.