### PR TITLE
Fix error in `FacialSignal` `make()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) convention.
 
+## [0.1.7] - 2023-10-18
+
++ Fix - Index `mot_Sv` and `movSv` by `roi_no` in `FacialSignal` 
+
 ## [0.1.6] - 2023-05-22
 
 + Add - Facemap citation

--- a/element_facemap/facial_behavior_estimation.py
+++ b/element_facemap/facial_behavior_estimation.py
@@ -463,7 +463,9 @@ class FacialSignal(dj.Imported):
                     key,
                     roi_no=roi_no,
                     pc_no=i,
-                    singular_value=dataset["motSv"][i] if "motSv" in dataset else None,
+                    singular_value=dataset["motSv"][roi_no][i]
+                    if "motSv" in dataset
+                    else None,
                     motmask=dataset["motMask_reshape"][roi_no + 1][:, :, i],
                     projection=dataset["motSVD"][roi_no + 1][i],
                 )
@@ -479,7 +481,9 @@ class FacialSignal(dj.Imported):
                     key,
                     roi_no=roi_no,
                     pc_no=i,
-                    singular_value=dataset["movSv"][i] if "movSv" in dataset else None,
+                    singular_value=dataset["movSv"][roi_no][i]
+                    if "movSv" in dataset
+                    else None,
                     movmask=dataset["movMask_reshape"][roi_no + 1][:, :, i],
                     projection=dataset["movSVD"][roi_no + 1][i],
                 )

--- a/element_facemap/version.py
+++ b/element_facemap/version.py
@@ -1,2 +1,2 @@
 """Package metadata."""
-__version__ = "0.1.6"
+__version__ = "0.1.7"


### PR DESCRIPTION
This PR will resolve the following error stack:
```
Traceback (most recent call last):
  File "/opt/conda/lib/python3.9/site-packages/datajoint/autopopulate.py", line 314, in _populate1
    make(dict(key), **(make_kwargs or {}))
  File "/opt/conda/lib/python3.9/site-packages/element_facemap/facial_behavior_estimation.py", line 461, in make
    entry = [
  File "/opt/conda/lib/python3.9/site-packages/element_facemap/facial_behavior_estimation.py", line 466, in <listcomp>
    singular_value=dataset["motSv"][i] if "motSv" in dataset else None,
IndexError: list index out of range
```
 
