### PR TITLE
Modify `FacemapPoseEstimationTask` table definition 

### DIFF
--- a/element_facemap/facemap_inference.py
+++ b/element_facemap/facemap_inference.py
@@ -221,7 +221,7 @@ class FacemapPoseEstimationTask(dj.Manual):
     -> fbe.VideoRecording
     -> FacemapModel
     ---
-    pose_estimation_output_dir    : varchar(255)  # output dir - stores results of Facemap Pose estimation analysis
+    pose_estimation_output_dir='' : varchar(255)  # output dir - stores results of Facemap Pose estimation analysis
     task_description              : varchar(128)  # Optional. Addtional task description
     task_mode='trigger'           : enum('load', 'trigger')
     bbox=null                     : longblob  # list containing bounding box for cropping the video [x1, x2, y1, y2]


### PR DESCRIPTION
- Allow for `pose_estimation_output_dir` to be an optional input
- This modifies the table definition for the `FacemapPoseEstimationTask`, so we would need to drop the current tables used for testing on the vathes-team_facemap workflow and re-ingest them.